### PR TITLE
Handle missing render contexts in VR rendering

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -198,6 +198,11 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 		m_VR->CreateVRTextures();
 
 	IMatRenderContext* rndrContext = m_Game->m_MaterialSystem->GetRenderContext();
+	if (!rndrContext)
+	{
+		m_VR->HandleMissingRenderContext("Hooks::dRenderView");
+		return hkRenderView.fOriginal(ecx, setup, hudViewSetup, nClearFlags, whatToDraw);
+	}
 
 	CViewSetup leftEyeView = setup;
 	CViewSetup rightEyeView = setup;
@@ -696,9 +701,16 @@ void Hooks::dPushRenderTargetAndViewport(void *ecx, void *edx, ITexture *pTextur
 	// then it pushed the HUD/GUI render target to the RT stack.
 	if (m_PushHUDStep == 3)
 	{
+		ITexture *originalTexture = pTexture;
 		pTexture = m_VR->m_HUDTexture;
 
 		IMatRenderContext *renderContext = m_Game->m_MaterialSystem->GetRenderContext();
+		if (!renderContext)
+		{
+			m_VR->HandleMissingRenderContext("Hooks::dPushRenderTargetAndViewport");
+			return hkPushRenderTargetAndViewport.fOriginal(ecx, originalTexture, pDepthTexture, nViewX, nViewY, nViewW, nViewH);
+		}
+
 		renderContext->ClearBuffers(false, true, true);
 
 		hkPushRenderTargetAndViewport.fOriginal(ecx, pTexture, pDepthTexture, nViewX, nViewY, nViewW, nViewH);
@@ -725,8 +737,15 @@ void Hooks::dPopRenderTargetAndViewport(void *ecx, void *edx)
 
 	if (m_PushedHud)
 	{
-		m_Game->m_MaterialSystem->GetRenderContext()->OverrideAlphaWriteEnable(false, true);
-		m_Game->m_MaterialSystem->GetRenderContext()->ClearColor4ub(0, 0, 0, 255);
+		IMatRenderContext *renderContext = m_Game->m_MaterialSystem->GetRenderContext();
+		if (!renderContext)
+		{
+			m_VR->HandleMissingRenderContext("Hooks::dPopRenderTargetAndViewport");
+			return hkPopRenderTargetAndViewport.fOriginal(ecx);
+		}
+
+		renderContext->OverrideAlphaWriteEnable(false, true);
+		renderContext->ClearColor4ub(0, 0, 0, 255);
 	}
 
 	hkPopRenderTargetAndViewport.fOriginal(ecx);

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -156,6 +156,15 @@ void VR::InstallApplicationManifest(const char* fileName)
     vr::VRApplications()->AddApplicationManifest(path);
 }
 
+void VR::HandleMissingRenderContext(const char* location)
+{
+    const char* ctx = location ? location : "unknown";
+    LOG("[VR] Missing IMatRenderContext in %s. Disabling VR rendering for this frame.", ctx);
+    m_CreatedVRTextures = false;
+    m_RenderedNewFrame = false;
+    m_RenderedHud = false;
+}
+
 void VR::Update()
 {
     if (!m_IsInitialized || !m_Game->m_Initialized)
@@ -167,6 +176,11 @@ void VR::Update()
         if (!m_Game->m_EngineClient->IsInGame())
         {
             IMatRenderContext* rndrContext = m_Game->m_MaterialSystem->GetRenderContext();
+            if (!rndrContext)
+            {
+                HandleMissingRenderContext("VR::Update");
+                return;
+            }
             rndrContext->SetRenderTarget(NULL);
             m_Game->m_CachedArmsModel = false;
             m_CreatedVRTextures = false; // Have to recreate textures otherwise some workshop maps won't render
@@ -195,8 +209,15 @@ bool VR::GetWalkAxis(float& x, float& y) {
 
 void VR::CreateVRTextures()
 {
+    IMatRenderContext* renderContext = m_Game->m_MaterialSystem->GetRenderContext();
+    if (!renderContext)
+    {
+        HandleMissingRenderContext("VR::CreateVRTextures");
+        return;
+    }
+
     int windowWidth, windowHeight;
-    m_Game->m_MaterialSystem->GetRenderContext()->GetWindowSize(windowWidth, windowHeight);
+    renderContext->GetWindowSize(windowWidth, windowHeight);
 
     m_Game->m_MaterialSystem->isGameRunning = false;
     m_Game->m_MaterialSystem->BeginRenderTargetAllocation();

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -198,6 +198,7 @@ public:
 	void InstallApplicationManifest(const char *fileName);
 	void Update();
 	void CreateVRTextures();
+	void HandleMissingRenderContext(const char* location);
 	void SubmitVRTextures();
 	void RepositionOverlays();
 	void GetPoses();


### PR DESCRIPTION
## Summary
- add a helper in VR to log and reset state when the material render context is unavailable
- gate VR texture creation and update paths behind render context checks to skip rendering for the frame
- guard render view and render target hooks so they fall back to the original behaviour when no context is returned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df3bff74f883218d2933d3223fc6ad