### PR TITLE
Keep VR aiming laser persistent and thicker

### DIFF
--- a/L4D2VR/game.cpp
+++ b/L4D2VR/game.cpp
@@ -13,6 +13,7 @@
 #include "hooks.h"
 #include "offsets.h"
 #include "sigscanner.h"
+#include "sdk/ivdebugoverlay.h"
 
 static std::mutex logMutex;
 using tCreateInterface = void* (__cdecl*)(const char* name, int* returnCode);
@@ -67,6 +68,21 @@ static void* GetInterfaceSafe(const char* dllname, const char* interfacename)
     return iface;
 }
 
+// === Utility: Attempt interface fetch without error logging ===
+static void* TryInterfaceNoError(const char* dllname, const char* interfacename)
+{
+    HMODULE mod = GetModuleWithRetry(dllname);
+    if (!mod)
+        return nullptr;
+
+    auto CreateInterface = reinterpret_cast<tCreateInterface>(GetProcAddress(mod, "CreateInterface"));
+    if (!CreateInterface)
+        return nullptr;
+
+    int returnCode = 0;
+    return CreateInterface(interfacename, &returnCode);
+}
+
 // === Game Constructor ===
 Game::Game()
 {
@@ -84,6 +100,9 @@ Game::Game()
     m_ModelRender = static_cast<IModelRender*>(GetInterfaceSafe("engine.dll", "VEngineModel016"));
     m_VguiInput = static_cast<IInput*>(GetInterfaceSafe("vgui2.dll", "VGUI_InputInternal001"));
     m_VguiSurface = static_cast<ISurface*>(GetInterfaceSafe("vguimatsurface.dll", "VGUI_Surface031"));
+    m_DebugOverlay = static_cast<IVDebugOverlay*>(TryInterfaceNoError("engine.dll", "VDebugOverlay004"));
+    if (!m_DebugOverlay)
+        m_DebugOverlay = static_cast<IVDebugOverlay*>(TryInterfaceNoError("engine.dll", "VDebugOverlay003"));
 
     m_Offsets = new Offsets();
     m_VR = new VR(this);

--- a/L4D2VR/game.h
+++ b/L4D2VR/game.h
@@ -22,6 +22,7 @@ class ISurface;
 class CBaseEntity;
 class C_BasePlayer;
 struct model_t;
+class IVDebugOverlay;
 
 // === Forward Declarations for Internal Systems ===
 class Game;
@@ -60,6 +61,7 @@ public:
     IModelRender* m_ModelRender = nullptr;
     IInput* m_VguiInput = nullptr;
     ISurface* m_VguiSurface = nullptr;
+    IVDebugOverlay* m_DebugOverlay = nullptr;
 
     // === Module Base Addresses ===
     uintptr_t m_BaseEngine = 0;

--- a/L4D2VR/sdk/ivdebugoverlay.h
+++ b/L4D2VR/sdk/ivdebugoverlay.h
@@ -1,0 +1,13 @@
+#pragma once
+
+class Vector;
+class QAngle;
+
+class IVDebugOverlay
+{
+public:
+    virtual void AddEntityTextOverlay(int ent_index, int line_offset, float duration, int r, int g, int b, int a, const char* format, ...) = 0;
+    virtual void AddBoxOverlay(const Vector& origin, const Vector& mins, const Vector& max, const QAngle& orientation, int r, int g, int b, int a, float duration) = 0;
+    virtual void AddTriangleOverlay(const Vector& p1, const Vector& p2, const Vector& p3, int r, int g, int b, int a, bool noDepthTest, float duration) = 0;
+    virtual void AddLineOverlay(const Vector& origin, const Vector& dest, int r, int g, int b, bool noDepthTest, float duration) = 0;
+};

--- a/L4D2VR/sdk/trace.h
+++ b/L4D2VR/sdk/trace.h
@@ -184,27 +184,47 @@ public:
 class CTraceFilterSkipNPCsAndPlayers : public CTraceFilter
 {
 public:
-	CTraceFilterSkipNPCsAndPlayers(IHandleEntity *passentity, int collisionGroup)
-		: CTraceFilter(passentity, collisionGroup)
-	{
-	}
+        CTraceFilterSkipNPCsAndPlayers(IHandleEntity *passentity, int collisionGroup)
+                : CTraceFilter(passentity, collisionGroup)
+        {
+        }
 
-	virtual bool ShouldHitEntity(IHandleEntity *pServerEntity, int contentsMask)
-	{
-		C_BasePlayer *pEntity = (C_BasePlayer *)pServerEntity;
-		if (!pEntity)
-			return true;
+        virtual bool ShouldHitEntity(IHandleEntity *pServerEntity, int contentsMask)
+        {
+                C_BasePlayer *pEntity = (C_BasePlayer *)pServerEntity;
+                if (!pEntity)
+                        return true;
 
-		if (m_pPassEnt == pServerEntity)
-			return false;
+                if (m_pPassEnt == pServerEntity)
+                        return false;
 
-		if (pEntity->IsNPC() || pEntity->IsPlayer())
-		{
-			return false;
-		}
+                if (pEntity->IsNPC() || pEntity->IsPlayer())
+                {
+                        return false;
+                }
 
-		return true;
-	}
+                return true;
+        }
+};
+
+class CTraceFilterSkipSelf : public CTraceFilter
+{
+public:
+        CTraceFilterSkipSelf(IHandleEntity *passentity, int collisionGroup)
+                : CTraceFilter(passentity, collisionGroup)
+        {
+        }
+
+        virtual bool ShouldHitEntity(IHandleEntity *pServerEntity, int contentsMask)
+        {
+                if (!pServerEntity)
+                        return true;
+
+                if (m_pPassEnt == pServerEntity)
+                        return false;
+
+                return true;
+        }
 };
 
 

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -4,6 +4,7 @@
 #include "game.h"
 #include "hooks.h"
 #include "trace.h"
+#include "sdk/ivdebugoverlay.h"
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -1043,6 +1044,8 @@ void VR::UpdateTracking()
     m_RightControllerForward = VectorRotate(m_RightControllerForward, m_RightControllerRight, -45.0);
     m_RightControllerUp = VectorRotate(m_RightControllerUp, m_RightControllerRight, -45.0);
 
+    UpdateAimingLaser(localPlayer);
+
     // controller angles
     QAngle::VectorAngles(m_LeftControllerForward, m_LeftControllerUp, m_LeftControllerAngAbs);
     QAngle::VectorAngles(m_RightControllerForward, m_RightControllerUp, m_RightControllerAngAbs);
@@ -1067,6 +1070,59 @@ void VR::UpdateTracking()
     // Viewmodel roll offset
     m_ViewmodelRight = VectorRotate(m_ViewmodelRight, m_ViewmodelForward, m_ViewmodelAngOffset.z);
     m_ViewmodelUp = VectorRotate(m_ViewmodelUp, m_ViewmodelForward, m_ViewmodelAngOffset.z);
+}
+
+void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
+{
+    m_HasAimLine = false;
+
+    if (!m_Game->m_DebugOverlay || !localPlayer || !m_Game->m_EngineClient->IsInGame())
+        return;
+
+    Vector direction = m_RightControllerForward;
+    if (direction.IsZero())
+        direction = m_LastAimDirection;
+
+    if (direction.IsZero())
+        return;
+
+    VectorNormalize(direction);
+    m_LastAimDirection = direction;
+
+    Vector origin = m_RightControllerPosAbs + direction * 2.0f;
+    const float maxDistance = 8192.0f;
+    Vector target = origin + direction * maxDistance;
+
+    Ray_t ray;
+    ray.Init(origin, target);
+
+    CGameTrace trace;
+    CTraceFilterSkipSelf tracefilter((IHandleEntity*)localPlayer, 0);
+    m_Game->m_EngineTrace->TraceRay(ray, STANDARD_TRACE_MASK, &tracefilter, &trace);
+
+    if (trace.fraction < 1.0f)
+        target = trace.endpos;
+
+    m_AimLineStart = origin;
+    m_AimLineEnd = target;
+    m_HasAimLine = true;
+
+    const float beamHalfWidth = 0.75f;
+    Vector right = m_RightControllerRight;
+    Vector up = m_RightControllerUp;
+    if (!right.IsZero())
+        VectorNormalize(right);
+    if (!up.IsZero())
+        VectorNormalize(up);
+
+    Vector offsetRight = right * beamHalfWidth;
+    Vector offsetUp = up * beamHalfWidth;
+
+    m_Game->m_DebugOverlay->AddLineOverlay(origin, target, 0, 255, 0, false, 0.05f);
+    m_Game->m_DebugOverlay->AddLineOverlay(origin + offsetRight, target + offsetRight, 0, 255, 0, false, 0.05f);
+    m_Game->m_DebugOverlay->AddLineOverlay(origin - offsetRight, target - offsetRight, 0, 255, 0, false, 0.05f);
+    m_Game->m_DebugOverlay->AddLineOverlay(origin + offsetUp, target + offsetUp, 0, 255, 0, false, 0.05f);
+    m_Game->m_DebugOverlay->AddLineOverlay(origin - offsetUp, target - offsetUp, 0, 255, 0, false, 0.05f);
 }
 
 Vector VR::GetViewAngle()

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -6,6 +6,7 @@
 #define MAX_STR_LEN 256
 
 class Game;
+class C_BasePlayer;
 class IDirect3DTexture9;
 class IDirect3DSurface9;
 class ITexture;
@@ -95,8 +96,13 @@ public:
 	Vector m_RightControllerPosAbs;											
 	QAngle m_RightControllerAngAbs;
 
-	Vector m_ViewmodelPosOffset;
-	QAngle m_ViewmodelAngOffset;
+        Vector m_ViewmodelPosOffset;
+        QAngle m_ViewmodelAngOffset;
+
+        Vector m_AimLineStart = { 0,0,0 };
+        Vector m_AimLineEnd = { 0,0,0 };
+        Vector m_LastAimDirection = { 0,0,0 };
+        bool m_HasAimLine = false;
 
 	float m_Ipd;																	
 	float m_EyeZ;
@@ -216,8 +222,9 @@ public:
 	bool GetAnalogActionData(vr::VRActionHandle_t &actionHandle, vr::InputAnalogActionData_t &analogDataOut);
 	void ResetPosition();
 	void GetPoseData(vr::TrackedDevicePose_t &poseRaw, TrackedDevicePoseData &poseOut);
-	void ParseConfigFile();
-	void WaitForConfigUpdate();
-	bool GetWalkAxis(float &x, float &y);
-	bool m_EncodeVRUsercmd = true;
+        void ParseConfigFile();
+        void WaitForConfigUpdate();
+        bool GetWalkAxis(float &x, float &y);
+        bool m_EncodeVRUsercmd = true;
+        void UpdateAimingLaser(C_BasePlayer* localPlayer);
 };


### PR DESCRIPTION
## Summary
- remember the last valid controller direction so the VR aiming laser continues rendering every frame
- increase the laser's overlay lifetime and draw multiple offset segments to create a thicker beam

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68df2b0bb6948321b969aa0ed9460d62