### PR TITLE
Ensure aiming laser renders continuously

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1095,36 +1095,41 @@ void VR::UpdateTracking()
 
 void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
 {
-    m_HasAimLine = false;
-
-    if (!m_Game->m_DebugOverlay || !localPlayer || !m_Game->m_EngineClient->IsInGame())
+    if (!m_Game->m_DebugOverlay)
         return;
+
+    (void)localPlayer;
 
     Vector direction = m_RightControllerForward;
     if (direction.IsZero())
-        return;
+    {
+        if (m_LastAimDirection.IsZero())
+        {
+            if (!m_HasAimLine)
+                return;
 
+            // Reuse the previous line when the controller forward can't be resolved at all.
+            m_Game->m_DebugOverlay->AddLineOverlay(m_AimLineStart, m_AimLineEnd, 0, 255, 0, false, 0.1f);
+            return;
+        }
+
+        direction = m_LastAimDirection;
+    }
+    else
+    {
+        m_LastAimDirection = direction;
+    }
     VectorNormalize(direction);
 
     Vector origin = m_RightControllerPosAbs + direction * 2.0f;
     const float maxDistance = 8192.0f;
     Vector target = origin + direction * maxDistance;
 
-    Ray_t ray;
-    ray.Init(origin, target);
-
-    CGameTrace trace;
-    CTraceFilterSkipSelf tracefilter((IHandleEntity*)localPlayer, 0);
-    m_Game->m_EngineTrace->TraceRay(ray, STANDARD_TRACE_MASK, &tracefilter, &trace);
-
-    if (trace.fraction < 1.0f)
-        target = trace.endpos;
-
     m_AimLineStart = origin;
     m_AimLineEnd = target;
     m_HasAimLine = true;
 
-    m_Game->m_DebugOverlay->AddLineOverlay(origin, target, 0, 255, 0, false, 0.01f);
+    m_Game->m_DebugOverlay->AddLineOverlay(origin, target, 0, 255, 0, false, 0.1f);
 }
 
 Vector VR::GetViewAngle()

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -101,6 +101,7 @@ public:
 
         Vector m_AimLineStart = { 0,0,0 };
         Vector m_AimLineEnd = { 0,0,0 };
+        Vector m_LastAimDirection = { 0,0,0 };
         bool m_HasAimLine = false;
 
 	float m_Ipd;																	


### PR DESCRIPTION
## Summary
- keep the cached aiming line so the debug overlay beam persists even when controller tracking momentarily fails
- always render the laser to its maximum range and extend its overlay lifetime so the beam no longer disappears or flickers on different targets

## Testing
- not run (VR feature change)


------
https://chatgpt.com/codex/tasks/task_e_68df51c789a08321b40ee2e5d469ecd2