### PR TITLE
Add crouch modifier combos to VR controls

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -433,18 +433,22 @@ void VR::GetViewParameters()
 
 bool VR::PressedDigitalAction(vr::VRActionHandle_t& actionHandle, bool checkIfActionChanged)
 {
-    vr::InputDigitalActionData_t digitalActionData;
-    vr::EVRInputError result = m_Input->GetDigitalActionData(actionHandle, &digitalActionData, sizeof(digitalActionData), vr::k_ulInvalidInputValueHandle);
+    vr::InputDigitalActionData_t digitalActionData{};
 
-    if (result == vr::VRInputError_None)
-    {
-        if (checkIfActionChanged)
-            return digitalActionData.bState && digitalActionData.bChanged;
-        else
-            return digitalActionData.bState;
-    }
+    if (!GetDigitalActionData(actionHandle, digitalActionData))
+        return false;
 
-    return false;
+    if (checkIfActionChanged)
+        return digitalActionData.bState && digitalActionData.bChanged;
+
+    return digitalActionData.bState;
+}
+
+bool VR::GetDigitalActionData(vr::VRActionHandle_t& actionHandle, vr::InputDigitalActionData_t& digitalDataOut)
+{
+    vr::EVRInputError result = m_Input->GetDigitalActionData(actionHandle, &digitalDataOut, sizeof(digitalDataOut), vr::k_ulInvalidInputValueHandle);
+
+    return result == vr::VRInputError_None;
 }
 
 bool VR::GetAnalogActionData(vr::VRActionHandle_t& actionHandle, vr::InputAnalogActionData_t& analogDataOut)
@@ -692,7 +696,50 @@ void VR::ProcessInput()
         m_Game->ClientCmd_Unrestricted("-use");
     }
 
-    if (PressedDigitalAction(m_ActionReload))
+    vr::InputDigitalActionData_t crouchActionData{};
+    bool crouchDataValid = GetDigitalActionData(m_ActionCrouch, crouchActionData);
+    bool crouchButtonDown = crouchDataValid && crouchActionData.bState;
+    bool crouchJustPressed = crouchDataValid && crouchActionData.bState && crouchActionData.bChanged;
+
+    vr::InputDigitalActionData_t resetActionData{};
+    bool resetDataValid = GetDigitalActionData(m_ActionResetPosition, resetActionData);
+    bool resetJustPressed = resetDataValid && resetActionData.bState && resetActionData.bChanged;
+
+    vr::InputDigitalActionData_t reloadActionData{};
+    bool reloadDataValid = GetDigitalActionData(m_ActionReload, reloadActionData);
+    bool reloadButtonDown = reloadDataValid && reloadActionData.bState;
+    bool reloadJustPressed = reloadDataValid && reloadActionData.bState && reloadActionData.bChanged;
+
+    vr::InputDigitalActionData_t flashlightActionData{};
+    bool flashlightDataValid = GetDigitalActionData(m_ActionFlashlight, flashlightActionData);
+    bool flashlightJustPressed = flashlightDataValid && flashlightActionData.bState && flashlightActionData.bChanged;
+
+    if (resetJustPressed)
+    {
+        if (crouchButtonDown)
+        {
+            m_Game->ClientCmd_Unrestricted("vote no");
+        }
+        else
+        {
+            m_CrouchToggleActive = !m_CrouchToggleActive;
+            ResetPosition();
+        }
+    }
+
+    if (!m_VoiceRecordActive && ((crouchButtonDown && reloadJustPressed) || (reloadButtonDown && crouchJustPressed)))
+    {
+        m_Game->ClientCmd_Unrestricted("+voicerecord");
+        m_VoiceRecordActive = true;
+    }
+
+    if (m_VoiceRecordActive && (!crouchButtonDown || !reloadButtonDown || !crouchDataValid || !reloadDataValid))
+    {
+        m_Game->ClientCmd_Unrestricted("-voicerecord");
+        m_VoiceRecordActive = false;
+    }
+
+    if (!crouchButtonDown && reloadButtonDown)
     {
         m_Game->ClientCmd_Unrestricted("+reload");
     }
@@ -710,21 +757,20 @@ void VR::ProcessInput()
         m_Game->ClientCmd_Unrestricted("-attack2");
     }
 
-    if (PressedDigitalAction(m_ActionPrevItem, true))
+    if (crouchButtonDown)
     {
-        m_Game->ClientCmd_Unrestricted("invprev");
-    }
-    else if (PressedDigitalAction(m_ActionNextItem, true))
-    {
-        m_Game->ClientCmd_Unrestricted("invnext");
-    }
-
-    if (PressedDigitalAction(m_ActionResetPosition, true))
-    {
-        ResetPosition();
+        if (PressedDigitalAction(m_ActionPrevItem, true))
+        {
+            m_Game->ClientCmd_Unrestricted("invprev");
+        }
+        else if (PressedDigitalAction(m_ActionNextItem, true))
+        {
+            m_Game->ClientCmd_Unrestricted("invnext");
+        }
     }
 
-    if (PressedDigitalAction(m_ActionCrouch))
+    bool crouchActive = crouchButtonDown || m_CrouchToggleActive;
+    if (crouchActive)
     {
         m_Game->ClientCmd_Unrestricted("+duck");
     }
@@ -733,9 +779,12 @@ void VR::ProcessInput()
         m_Game->ClientCmd_Unrestricted("-duck");
     }
 
-    if (PressedDigitalAction(m_ActionFlashlight, true))
+    if (flashlightJustPressed)
     {
-        m_Game->ClientCmd_Unrestricted("impulse 100");
+        if (crouchButtonDown)
+            m_Game->ClientCmd_Unrestricted("vote yes");
+        else
+            m_Game->ClientCmd_Unrestricted("impulse 100");
     }
 
     if (PressedDigitalAction(m_Spray, true))

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -143,8 +143,10 @@ public:
 	bool m_CreatedVRTextures = false;
 	TextureID m_CreatingTextureID = Texture_None;
 
-	bool m_PressedTurn = false;
-	bool m_PushingThumbstick = false;
+        bool m_PressedTurn = false;
+        bool m_PushingThumbstick = false;
+        bool m_CrouchToggleActive = false;
+        bool m_VoiceRecordActive = false;
 
 	// action set
 	vr::VRActionSetHandle_t m_ActionSet;
@@ -222,6 +224,7 @@ public:
         Vector GetViewOriginLeft();
         Vector GetViewOriginRight();
         bool PressedDigitalAction(vr::VRActionHandle_t &actionHandle, bool checkIfActionChanged = false);
+        bool GetDigitalActionData(vr::VRActionHandle_t& actionHandle, vr::InputDigitalActionData_t& digitalDataOut);
         bool GetAnalogActionData(vr::VRActionHandle_t &actionHandle, vr::InputAnalogActionData_t &analogDataOut);
         void ResetPosition();
         void GetPoseData(vr::TrackedDevicePose_t &poseRaw, TrackedDevicePoseData &poseOut);


### PR DESCRIPTION
## Summary
- add internal state for crouch toggling via the ResetPosition action and expose digital action queries for combo handling
- implement crouch-modified bindings for voice chat, vote yes/no, and inventory cycling while preserving normal reload/flashlight behavior otherwise

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68df60c7f1fc832181d33cc02ece1745