### PR TITLE
Add switches for VR support and reticle visibility

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -9,4 +9,6 @@ HideArms=false
 HudDistance=1.3
 HudSize=1.1
 HudAlwaysVisible=false
-EncodeVRUsercmd=true
+ForceNonVRServerMovement=false
+AimLineEnabled=true
+AimLineThickness=2.0

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -255,6 +255,7 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
     bool result = hkCreateMove.fOriginal(ecx, flInputSampleTime, cmd);
 
     if (m_VR->m_IsVREnabled) {
+        const bool treatServerAsNonVR = (!Hooks::s_ServerUnderstandsVR) || m_VR->m_ForceNonVRServerMovement;
         float ax = 0.f, ay = 0.f;
         if (m_VR->GetWalkAxis(ax, ay)) {
             // 死区 + 归一化（和平滑转向一致的 0.2 死区）
@@ -284,20 +285,20 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 
         }
 
-		// ② ★ 非 VR 服务器：把“右手手柄朝向”塞给服务器用的视角
-		if (!Hooks::s_ServerUnderstandsVR) {
-			QAngle aim = m_VR->GetRightControllerAbsAngle();
-			// 简单夹角，避免异常值
-			if (aim.x > 89.f)  aim.x = 89.f;
-			if (aim.x < -89.f) aim.x = -89.f;
-			// yaw 归一到 [-180,180]
-			while (aim.y > 180.f)  aim.y -= 360.f;
-			while (aim.y < -180.f) aim.y += 360.f;
+        // ② ★ 非 VR 服务器：把“右手手柄朝向”塞给服务器用的视角
+        if (treatServerAsNonVR) {
+            QAngle aim = m_VR->GetRightControllerAbsAngle();
+            // 简单夹角，避免异常值
+            if (aim.x > 89.f)  aim.x = 89.f;
+            if (aim.x < -89.f) aim.x = -89.f;
+            // yaw 归一到 [-180,180]
+            while (aim.y > 180.f)  aim.y -= 360.f;
+            while (aim.y < -180.f) aim.y += 360.f;
 
-			cmd->viewangles.x = aim.x;   // pitch
-			cmd->viewangles.y = aim.y;   // yaw
-			cmd->viewangles.z = 0.f;     // roll 一般不用
-		}
+            cmd->viewangles.x = aim.x;   // pitch
+            cmd->viewangles.y = aim.y;   // yaw
+            cmd->viewangles.z = 0.f;     // roll 一般不用
+        }
     }
 
     return result;
@@ -530,8 +531,8 @@ int Hooks::dWriteUsercmd(void* buf, CUserCmd* to, CUserCmd* from)
 	if (!m_VR->m_IsVREnabled)
 		return hkWriteUsercmd.fOriginal(buf, to, from);
 
-	// 只有（配置开启编码）且（本进程确实在跑服务器钩子＝能解码）时才编码
-	const bool canEncode = (m_VR->m_EncodeVRUsercmd && Hooks::s_ServerUnderstandsVR);
+        // 只有（配置开启编码）且（本进程确实在跑服务器钩子＝能解码）且（未强制走非 VR 标准）时才编码
+        const bool canEncode = (m_VR->m_EncodeVRUsercmd && Hooks::s_ServerUnderstandsVR && !m_VR->m_ForceNonVRServerMovement);
 
 	if (!canEncode)
 	{

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1191,7 +1191,7 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
 
 bool VR::ShouldShowAimLine(C_WeaponCSBase* weapon) const
 {
-    if (!weapon)
+    if (!m_AimLineEnabled || !weapon)
         return false;
 
     switch (weapon->GetWeaponID())
@@ -1224,6 +1224,9 @@ bool VR::ShouldShowAimLine(C_WeaponCSBase* weapon) const
 void VR::DrawAimLine(const Vector& start, const Vector& end)
 {
     if (!m_Game->m_DebugOverlay)
+        return;
+
+    if (!m_AimLineEnabled)
         return;
 
     const float duration = 0.0f;
@@ -1390,7 +1393,8 @@ void VR::ParseConfigFile()
     m_HudAlwaysVisible = getBool("HudAlwaysVisible", m_HudAlwaysVisible);
     m_HeadSmoothing = std::clamp(getFloat("HeadSmoothing", m_HeadSmoothing), 0.0f, 0.99f);
     m_AimLineThickness = std::max(0.0f, getFloat("AimLineThickness", m_AimLineThickness));
-    m_EncodeVRUsercmd = getBool("EncodeVRUsercmd", m_EncodeVRUsercmd);
+    m_AimLineEnabled = getBool("AimLineEnabled", m_AimLineEnabled);
+    m_ForceNonVRServerMovement = getBool("ForceNonVRServerMovement", m_ForceNonVRServerMovement);
 }
 
 void VR::WaitForConfigUpdate()

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -105,6 +105,7 @@ public:
         Vector m_LastAimDirection = { 0,0,0 };
         bool m_HasAimLine = false;
         float m_AimLineThickness = 2.0f;
+        bool m_AimLineEnabled = true;
 
 	float m_Ipd;																	
 	float m_EyeZ;
@@ -196,6 +197,8 @@ public:
         bool m_HudAlwaysVisible = false;
         float m_HeadSmoothing = 0.0f;
         bool m_HmdSmoothingInitialized = false;
+
+        bool m_ForceNonVRServerMovement = false;
 
         VR() {};
 	VR(Game *game);


### PR DESCRIPTION
## Summary
- remove the EncodeVRUsercmd toggle from the sample configuration
- stop parsing EncodeVRUsercmd from config so VR command encoding remains permanently enabled
- Added a ForceNonVRServerMovement config flag and applied it in movement and usercmd hooks so players can force standard non-VR walking behavior even on VR-capable servers.
- Introduced an AimLineEnabled toggle that can hide the aim line overlay while preserving thickness customization and ensured all aim-line rendering respects the new setting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df62dc9f088321abfdfdb022669afa