### PR TITLE
Reduce aiming laser flicker

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -12,5 +12,6 @@ HudAlwaysVisible=false
 ForceNonVRServerMovement=false
 AimLineEnabled=true
 AimLineThickness=2.0
+AimLinePersistence=0.02
 AimLineColor=0,255,0,192
 AntiAliasing=0

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1242,7 +1242,7 @@ void VR::DrawAimLine(const Vector& start, const Vector& end)
     if (!m_AimLineEnabled)
         return;
 
-    const float duration = 0.0f;
+    const float duration = std::max(m_AimLinePersistence, 0.0f);
     m_Game->m_DebugOverlay->AddLineOverlay(start, end, m_AimLineColorR, m_AimLineColorG, m_AimLineColorB, false, duration);
 
     const float thickness = std::max(m_AimLineThickness, 0.0f);
@@ -1451,6 +1451,7 @@ void VR::ParseConfigFile()
     m_HeadSmoothing = std::clamp(getFloat("HeadSmoothing", m_HeadSmoothing), 0.0f, 0.99f);
     m_AimLineThickness = std::max(0.0f, getFloat("AimLineThickness", m_AimLineThickness));
     m_AimLineEnabled = getBool("AimLineEnabled", m_AimLineEnabled);
+    m_AimLinePersistence = std::max(0.0f, getFloat("AimLinePersistence", m_AimLinePersistence));
     auto aimColor = getColor("AimLineColor", m_AimLineColorR, m_AimLineColorG, m_AimLineColorB, m_AimLineColorA);
     m_AimLineColorR = aimColor[0];
     m_AimLineColorG = aimColor[1];

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -107,6 +107,7 @@ public:
         bool m_HasAimLine = false;
         float m_AimLineThickness = 2.0f;
         bool m_AimLineEnabled = true;
+        float m_AimLinePersistence = 0.02f;
         int m_AimLineColorR = 0;
         int m_AimLineColorG = 255;
         int m_AimLineColorB = 0;


### PR DESCRIPTION
## Summary
- add a configurable persistence timer for the VR aim line
- default the aim line to persist for a short duration to mitigate frame-to-frame flicker

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfd9cdd4d083218aafde7dfdccbcf7